### PR TITLE
Feature: Support public keys

### DIFF
--- a/blocklistmaker
+++ b/blocklistmaker
@@ -97,10 +97,16 @@ for root, dirs, files in os.walk(args.source, followlinks=True):
                     )
                 except Exception as e:
                     try:
-                        pubkey = serialization.load_ssh_public_identity(key)
+                        priv = serialization.load_ssh_private_key(key, password=None, backend=mybackend)
+                        pubkey = priv.public_key()
                     except Exception as e:
-                        print(f"{root}/{fn} failed to load: #{e}")
-                        invalid = True
+                        try:
+                            pubkey = serialization.load_ssh_public_key(key)
+                        except Exception as e:
+                            try:
+                                pubkey = serialization.load_ssh_public_identity(key)
+                            except Exception as e:
+                                print(f"{root}/{fn} failed to load: #{e}")
 
             if isinstance(pubkey, rsa.RSAPublicKey):
                 rsa_n = pubkey.public_numbers().n

--- a/blocklistmaker
+++ b/blocklistmaker
@@ -70,6 +70,7 @@ for root, dirs, files in os.walk(args.source, followlinks=True):
         else:
             fpath = f"{sroot}/{fn}"
         with open(f"{root}/{fn}", "rb") as fkey:
+            pubkey = None
             key = fkey.read()
             try:
                 privkey = serialization.load_pem_private_key(
@@ -78,6 +79,7 @@ for root, dirs, files in os.walk(args.source, followlinks=True):
                     backend=mybackend,
                     unsafe_skip_rsa_key_validation=True,
                 )
+                pubkey = privkey.public_key()
             except TypeError:  # no password
                 flog.write(f"{root}/{fn} pem no password\n")
                 continue
@@ -87,17 +89,27 @@ for root, dirs, files in os.walk(args.source, followlinks=True):
             except NotImplementedError:  # strange EC curves
                 flog.write(f"{root}/{fn} pem not implemented\n")
                 continue
-            except (ValueError, OverflowError):
-                privkey = False
+            except Exception as e:
+                try:
+                    pubkey = serialization.load_pem_public_key(
+                        key,
+                        backend=mybackend,
+                    )
+                except Exception as e:
+                    try:
+                        pubkey = serialization.load_ssh_public_identity(key)
+                    except Exception as e:
+                        print(f"{root}/{fn} failed to load: #{e}")
+                        invalid = True
 
-            if isinstance(privkey, rsa.RSAPrivateKey):
-                rsa_n = privkey.public_key().public_numbers().n
+            if isinstance(pubkey, rsa.RSAPublicKey):
+                rsa_n = pubkey.public_numbers().n
                 s256 = hashnumber(rsa_n)
                 writehash(blid, s256, fpath, fs, fl)
 
-            elif isinstance(privkey, ec.EllipticCurvePrivateKey):
+            elif isinstance(pubkey, ec.EllipticCurvePublicKey):
                 try:
-                    ec_x = privkey.public_key().public_numbers().x
+                    ec_x = pubkey.public_numbers().x
                     s256 = hashnumber(ec_x)
                     writehash(blid, s256, fpath, fes, fel)
                 except cryptography.exceptions.InternalError:
@@ -105,12 +117,12 @@ for root, dirs, files in os.walk(args.source, followlinks=True):
                     flog.write(f"{root}/{fn} internal error ecdsa\n")
 
             elif (
-                isinstance(privkey, (ed25519.Ed25519PrivateKey, x25519.X25519PrivateKey,
-                                     x448.X448PrivateKey, ed448.Ed448PrivateKey))
+                isinstance(pubkey, (ed25519.Ed25519PublicKey, x25519.X25519PublicKey,
+                                     x448.X448PublicKey, ed448.Ed448PublicKey))
             ):
                 try:
                     # "raw" ed25519 keys are simply the x coordinate
-                    ec_xb = privkey.public_key().public_bytes(
+                    ec_xb = pubkey.public_bytes(
                         encoding=serialization.Encoding.Raw,
                         format=serialization.PublicFormat.Raw,
                     )
@@ -121,14 +133,14 @@ for root, dirs, files in os.walk(args.source, followlinks=True):
                     # happens with point at infinity test key
                     flog.write(f"{root}/{fn} internal error ed\n")
 
-            elif isinstance(privkey, dsa.DSAPrivateKey):
-                pub = privkey.public_key()
+            elif isinstance(pubkey, dsa.DSAPublicKey):
+                pub = pubkey
                 dsa_y = pub.public_numbers().y
                 s256 = hashnumber(dsa_y)
                 writehash(blid, s256, fpath, fds, fdl)
 
-            elif isinstance(privkey, dh.DHPrivateKey):
-                pub = privkey.public_key()
+            elif isinstance(pubkey, dh.DHPublicKey):
+                pub = pubkey
                 try:
                     dh_y = pub.public_numbers().y
                     s256 = hashnumber(dh_y)
@@ -137,9 +149,8 @@ for root, dirs, files in os.walk(args.source, followlinks=True):
                     # happens with implausibly small parameters
                     pass
 
-            elif privkey is not False:
-                flog.write(f"{root}/{fn} unknown type {type(privkey)}\n")
-                print(f"{root}/{fn} unknown type {type(privkey)}")
+            else:
+                flog.write(f"{root}/{fn} not a supported key {type(pubkey)}\n")
 
 
 fs.close()


### PR DESCRIPTION
This updates `blocklistmaker` to support public keys, including TLS certificates, SSH identities, host keys, and private keys. Attached is a zip containing a sample of widely-observed TLS and SSH public keys with annotations in PEM format.

These look something like:

```
count: 12
firstTS: 20241203
lastTS: 20241204
endpoints: 23.235.211.93:2222 104.244.120.133:2222 74.124.219.45:2222 205.134.250.181:2222 144.208.69.150:2222 104.247.75.67:2222 144.208.71.193:2222 205.134.238.245:2222 216.194.168.94:2222 173.247.249.183:2222 209.182.203.46:2222 144.208.68.144:2222
sha256: 807700d37feffe7ded382eac3ee00021831e370ad4128b636ff95bd0578b6424
type: ssh-rsa

-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAviN32hjr9t7DcdgW+Et4
HQGDEyV6vhQR77Bu2XnKugxKgB4SJNgceQ4sC+r5xlzvW9F5FvG/FcAUfcMtVfAg
Wf1yK29LSN3fmX+aSqjjfDYgsw/2shxTcHsato84kQycuCu17wcCe3yyAzrWj+CS
hZDWZHVYFCqI7D8AmiJWCJjTWJWOi9iDjeg57m2ik7qNZP/lP5OmSxHtQRMDzqiB
KTdaRTRafLJM0V/a5Bpt3/TEAxtUEwAJETfcf7TnxbOyWpktGeHy4D213tq0mNYX
rOGFJU/YTit0ryd1iFRtnF7U1P8H7TaM8bXdOWHYC9Qp6H6TYqyQFGrPmrPDpXz2
9QIDAQAB
-----END PUBLIC KEY-----
```

Note that the `sha256` is of the entire hostkey (or TLS certificate) and not the public key. The public key ID is effectively computed by the `blocklistmaker` (15b based on the key type).

[badkeys-sample-pubkeys.zip](https://github.com/user-attachments/files/18055959/badkeys-sample-pubkeys.zip)
